### PR TITLE
Correct i32 bit number range.

### DIFF
--- a/portable-simd.md
+++ b/portable-simd.md
@@ -18,7 +18,7 @@ unsigned integers.
 
 * `i8`: An 8-bit integer with bits numbered 0–7.
 * `i16`: A 16-bit integer with bits numbered 0–15.
-* `i32`: A 32-bit integer with bits numbered 0–32.
+* `i32`: A 32-bit integer with bits numbered 0–31.
 * `i64`: A 64-bit integer with bits numbered 0–63.
 
 The concrete scalar floating-point types follow the encoding and semantics of


### PR DESCRIPTION
Use an inclusive range like the other scalar types.